### PR TITLE
switch to weakref-based definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import uvicorn
 from fastapi import FastAPI, Response, status
 from fastapi.websockets import WebSocket
 
-from fastapi_controllers import Controller, get
+from fastapi_controllers import Controller, get, websocket
 
 
 class ExampleController(Controller):
@@ -141,8 +141,7 @@ if __name__ == "__main__":
     app.include_router(ExampleController.create_router())
     uvicorn.run(app)
 ```
->**Important**:
->**Beware of assigning values to the same parameter twice (directly on class-level and through `__router_params__`). The values stored in `__router_params__` have precedence and will override your other settings if a name conflict arises. E.g. the following `Controller` would create an `APIRouter` with `prefix=/override`, `tags=["override"]` and `dependencies=[Depends(override)]`**
+> :warning: **Important**: Beware of assigning values to the same parameter twice (directly on class-level and through `__router_params__`). The values stored in `__router_params__` have precedence and will override your other settings if a name conflict arises. E.g. the following `Controller` would create an `APIRouter` with `prefix=/override`, `tags=["override"]` and `dependencies=[Depends(override)]`
 
 ```python
 from fastapi import Depends
@@ -203,6 +202,5 @@ class ExampleController(Controller):
 if __name__ == "__main__":
     app = FastAPI()
     app.include_router(ExampleController.create_router())
-    uvicorn.run(app)
     uvicorn.run(app)
 ```

--- a/fastapi_controllers/controllers.py
+++ b/fastapi_controllers/controllers.py
@@ -1,11 +1,12 @@
 import inspect
+import weakref
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from fastapi import APIRouter, params
 
 from fastapi_controllers.definitions import HTTPRouteDefinition, RouteData, WebsocketRouteDefinition
-from fastapi_controllers.helpers import _replace_signature, _validate_against_apirouter_signature
+from fastapi_controllers.helpers import _replace_signature, _validate_against_signature
 
 
 class Controller:
@@ -20,7 +21,7 @@ class Controller:
         for param in ["prefix", "dependencies", "tags"]:
             if not cls.__router_params__.get(param):
                 cls.__router_params__[param] = getattr(cls, param)
-        _validate_against_apirouter_signature("__init__", kwargs=cls.__router_params__)
+        _validate_against_signature(weakref.proxy(APIRouter.__init__), kwargs=cls.__router_params__)
 
     @classmethod
     def create_router(cls) -> APIRouter:

--- a/fastapi_controllers/definitions.py
+++ b/fastapi_controllers/definitions.py
@@ -1,6 +1,9 @@
+import weakref
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Tuple
+
+from fastapi import APIRouter
 
 
 class HTTPRequestMethod(str, Enum):
@@ -15,12 +18,12 @@ class HTTPRequestMethod(str, Enum):
 
 
 class RouteDefinition:
-    def __init__(self, *, binds: str) -> None:
+    def __init__(self, *, binds: weakref.CallableProxyType) -> None:
         self.binds = binds
 
 
 class HTTPRouteDefinition(RouteDefinition):
-    def __init__(self, *, binds: str, request_method: HTTPRequestMethod) -> None:
+    def __init__(self, *, binds: weakref.CallableProxyType, request_method: HTTPRequestMethod) -> None:
         super().__init__(binds=binds)
         self.request_method = request_method
 
@@ -38,12 +41,12 @@ class RouteData:
 
 @dataclass
 class Route:
-    delete = HTTPRouteDefinition(binds="delete", request_method=HTTPRequestMethod.DELETE)
-    get = HTTPRouteDefinition(binds="get", request_method=HTTPRequestMethod.GET)
-    head = HTTPRouteDefinition(binds="head", request_method=HTTPRequestMethod.HEAD)
-    options = HTTPRouteDefinition(binds="options", request_method=HTTPRequestMethod.OPTIONS)
-    patch = HTTPRouteDefinition(binds="patch", request_method=HTTPRequestMethod.PATCH)
-    post = HTTPRouteDefinition(binds="post", request_method=HTTPRequestMethod.POST)
-    put = HTTPRouteDefinition(binds="put", request_method=HTTPRequestMethod.PUT)
-    trace = HTTPRouteDefinition(binds="trace", request_method=HTTPRequestMethod.TRACE)
-    websocket = WebsocketRouteDefinition(binds="websocket")
+    delete = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.delete), request_method=HTTPRequestMethod.DELETE)
+    get = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.get), request_method=HTTPRequestMethod.GET)
+    head = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.head), request_method=HTTPRequestMethod.HEAD)
+    options = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.options), request_method=HTTPRequestMethod.OPTIONS)
+    patch = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.patch), request_method=HTTPRequestMethod.PATCH)
+    post = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.post), request_method=HTTPRequestMethod.POST)
+    put = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.put), request_method=HTTPRequestMethod.PUT)
+    trace = HTTPRouteDefinition(binds=weakref.proxy(APIRouter.trace), request_method=HTTPRequestMethod.TRACE)
+    websocket = WebsocketRouteDefinition(binds=weakref.proxy(APIRouter.websocket))

--- a/fastapi_controllers/helpers.py
+++ b/fastapi_controllers/helpers.py
@@ -1,11 +1,12 @@
 import inspect
+import weakref
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 
 
-def _validate_against_apirouter_signature(
-    method_name: str,
+def _validate_against_signature(
+    method: weakref.CallableProxyType,
     args: Optional[Tuple[Any, ...]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
@@ -17,7 +18,7 @@ def _validate_against_apirouter_signature(
         args: The positional arguments of the method.
         kwargs: The keyword arguments of the method.
     """
-    target_sig = inspect.signature(getattr(APIRouter, method_name))
+    target_sig = inspect.signature(method)
     valid_sig = target_sig.replace(parameters=list(target_sig.parameters.values())[1:])
     valid_sig.bind(*(args or tuple()), **(kwargs or {}))
 

--- a/fastapi_controllers/routing.py
+++ b/fastapi_controllers/routing.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Tuple
 
 from fastapi_controllers.definitions import Route, RouteData, RouteDefinition
-from fastapi_controllers.helpers import _validate_against_apirouter_signature
+from fastapi_controllers.helpers import _validate_against_signature
 
 
 class _RouteDecorator:
@@ -14,7 +14,7 @@ class _RouteDecorator:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.route_args = args
         self.route_kwargs = kwargs
-        _validate_against_apirouter_signature(self._route_definition.binds, args=args, kwargs=kwargs)
+        _validate_against_signature(self._route_definition.binds, args=args, kwargs=kwargs)
 
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
         func.__route_data__ = RouteData(  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-controllers"
-version = "0.2.0"
+version = "0.2.1"
 description = "Simple Controller implementation for FastAPI"
 authors = ["Jerzy Góra <j.gora89@gmail.com>"]
 license = "MIT"

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -10,7 +10,7 @@ from fastapi_controllers.routing import get, websocket
 
 @pytest.fixture(autouse=True)
 def validator(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("fastapi_controllers.controllers._validate_against_apirouter_signature")
+    return mocker.patch("fastapi_controllers.controllers._validate_against_signature")
 
 
 def describe_Controller() -> None:
@@ -32,12 +32,16 @@ def describe_Controller() -> None:
             "deprecated": True,
         }
 
-    def it_validates_apirouter_parameters(validator: MagicMock) -> None:
+    def it_validates_apirouter_parameters(mocker: MockerFixture, validator: MagicMock) -> None:
+
+        mocked_proxy = mocker.patch("weakref.proxy", return_value="FAKE_PROXY")
+
         class _(Controller):
             ...
 
+        mocked_proxy.assert_called_once_with(APIRouter.__init__)
         validator.assert_called_once_with(
-            "__init__",
+            "FAKE_PROXY",
             kwargs={
                 "prefix": "",
                 "dependencies": None,

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,59 +1,54 @@
 import inspect
+import weakref
 from typing import Any
 
 import pytest
 from fastapi import params
-from pytest_mock import MockerFixture
 
-from fastapi_controllers.helpers import _replace_signature, _validate_against_apirouter_signature
-
-
-def fake_method(fake_self: Any, positional: Any, *, keyword: "str") -> None:
-    ...
+from fastapi_controllers.helpers import _replace_signature, _validate_against_signature
 
 
-@pytest.fixture(autouse=True)
-def apirouter(mocker: MockerFixture) -> None:
-    mocked_apirouter = mocker.patch("fastapi_controllers.helpers.APIRouter")
-    mocked_apirouter.test = fake_method
+class Fake:
+    def fake_method(self, positional: Any, *, keyword: "str") -> None:
+        ...
 
 
-def describe_validate_against_apirouter_signature() -> None:
-    def it_validates_method_parameters_agains_apirouter() -> None:
-        _validate_against_apirouter_signature(
-            method_name="test",
+def describe_validate_against_signature() -> None:
+    def it_validates_method_parameters_against_the_desired_signature() -> None:
+        _validate_against_signature(
+            weakref.proxy(Fake.fake_method),
             args=("test",),
             kwargs={"keyword": "TEST"},
         )
 
     def it_raises_an_error_on_missing_positional_args() -> None:
         with pytest.raises(TypeError):
-            _validate_against_apirouter_signature(
-                method_name="test",
+            _validate_against_signature(
+                weakref.proxy(Fake.fake_method),
                 args=tuple(),
                 kwargs={"keyword": "TEST"},
             )
 
     def it_raises_an_error_on_missing_keyword_args() -> None:
         with pytest.raises(TypeError):
-            _validate_against_apirouter_signature(
-                method_name="test",
+            _validate_against_signature(
+                weakref.proxy(Fake.fake_method),
                 args=("test",),
                 kwargs={},
             )
 
     def it_raises_an_error_on_additional_keyword_args() -> None:
         with pytest.raises(TypeError):
-            _validate_against_apirouter_signature(
-                method_name="test",
+            _validate_against_signature(
+                weakref.proxy(Fake.fake_method),
                 args=("test",),
                 kwargs={"keyword": "TEST", "additional": "TEST"},
             )
 
     def it_raises_an_error_on_additional_positional_args() -> None:
         with pytest.raises(TypeError):
-            _validate_against_apirouter_signature(
-                method_name="test",
+            _validate_against_signature(
+                weakref.proxy(Fake.fake_method),
                 args=("test", "test"),
                 kwargs={},
             )


### PR DESCRIPTION
- changes the route definitions to use weak refs to APIRouter methods instead of matching with by attribute name and `getattr`
- minor fixes to README.md