### PR TITLE
bump isort pre-commit to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/charliermarsh/ruff-pre-commit


### PR DESCRIPTION
- bump pre commit version for isort fixing https://github.com/PyCQA/isort/issues/2083